### PR TITLE
feat(forge): Add struct factory with schema validation support

### DIFF
--- a/packages/forge/package.json
+++ b/packages/forge/package.json
@@ -18,10 +18,12 @@
 		"test": "bun test"
 	},
 	"dependencies": {
-		"base-x": "^4.0.0"
+		"base-x": "^4.0.0",
+		"@standard-schema/spec": "catalog:"
 	},
 	"devDependencies": {
 		"@rslib/core": "catalog:",
-		"@types/bun": "latest"
+		"@types/bun": "latest",
+		"zod": "catalog:"
 	}
 }

--- a/packages/forge/src/index.test.ts
+++ b/packages/forge/src/index.test.ts
@@ -35,7 +35,7 @@ describe("struct", () => {
 	});
 
 	it("should only work with object schemas", () => {
-		// @ts-expect-error
+		// @ts-expect-error -- should only accept object schemas
 		const createUser = struct("user", z.string());
 		expect(() => createUser({name: "John Doe"})).toThrow();
 	});

--- a/packages/forge/src/index.test.ts
+++ b/packages/forge/src/index.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, it} from "bun:test";
-import {type Ref, factory} from ".";
+import {z} from "zod";
+import {type Ref, factory, struct} from ".";
 
 describe("factory", () => {
 	it("should work", () => {
@@ -23,5 +24,19 @@ describe("relationships", () => {
 		const comment = createComment(post.id, "Great post!");
 		expect(comment.postID).toEqual(post.id);
 		expect(comment.text).toEqual("Great post!");
+	});
+});
+
+describe("struct", () => {
+	it("should work", async () => {
+		const createUser = struct("user", z.object({name: z.string()}));
+		const user = createUser({name: "John Doe"});
+		expect(user.name).toEqual("John Doe");
+	});
+
+	it("should only work with object schemas", () => {
+		// @ts-expect-error
+		const createUser = struct("user", z.string());
+		expect(() => createUser({name: "John Doe"})).toThrow();
 	});
 });

--- a/packages/forge/src/index.ts
+++ b/packages/forge/src/index.ts
@@ -1,4 +1,6 @@
+import type {StandardSchemaV1 as StandardV1} from "@standard-schema/spec";
 import {b58} from "./id";
+import {validateSync} from "./validate";
 
 /**
  * Represents a uniquely identifiable entity with a type tag
@@ -74,5 +76,38 @@ export function factory<Tag extends string, CustomProps, Args extends any[]>(
 	return (...args: Args): Entity<Tag> & CustomProps => ({
 		...entity(tag),
 		...customPropsFactory(...args),
+	});
+}
+
+// biome-ignore lint/complexity/noBannedTypes: i want empty object
+type EmptyObject = {};
+
+/**
+ * Creates a factory function that produces tagged entities with additional properties.
+ * Combines a basic entity (tag + id) with custom properties.
+ *
+ * @example
+ * ```ts
+ * // Define a factory for creating users
+ * import {z} from 'zod';
+ * import * as v from 'valibot';
+ * // with zod
+ * const createUser = struct('user', z.object({name: z.string()}));
+ *
+ * // with valibot
+ * const createUser = struct('user', v.object({name: v.string()}));
+ *
+ * // Create a user with the factory
+ * const user = createUser({name: 'John'});
+ * // Result: { tag: 'user', id: 'user_x7f2k...', name: 'John' }
+ * ```
+ */
+export function struct<Tag extends string, T extends StandardV1<EmptyObject, EmptyObject>>(
+	tag: Tag,
+	schema: T,
+) {
+	return factory(tag, (parameters: StandardV1.InferInput<T>) => {
+		const result = validateSync(schema, parameters);
+		return result;
 	});
 }

--- a/packages/forge/src/index.ts
+++ b/packages/forge/src/index.ts
@@ -79,8 +79,7 @@ export function factory<Tag extends string, CustomProps, Args extends any[]>(
 	});
 }
 
-// biome-ignore lint/complexity/noBannedTypes: i want empty object
-type EmptyObject = {};
+type EmptyObject = {[key: string]: any};
 
 /**
  * Creates a factory function that produces tagged entities with additional properties.

--- a/packages/forge/src/validate.ts
+++ b/packages/forge/src/validate.ts
@@ -1,0 +1,31 @@
+import type {StandardSchemaV1} from "@standard-schema/spec";
+
+export function validateSync<T extends StandardSchemaV1>(
+	schema: T,
+	input: StandardSchemaV1.InferInput<T>,
+): StandardSchemaV1.InferOutput<T> {
+	const result = schema["~standard"].validate(input);
+	if (result instanceof Promise) {
+		throw new Error("async validation is not supported");
+	}
+
+	if (result.issues) {
+		throw new Error(JSON.stringify(result.issues, null, 2));
+	}
+
+	return result.value;
+}
+
+export async function validateAsync<T extends StandardSchemaV1>(
+	schema: T,
+	input: StandardSchemaV1.InferInput<T>,
+): Promise<StandardSchemaV1.InferOutput<T>> {
+	let result = schema["~standard"].validate(input);
+	if (result instanceof Promise) result = await result;
+
+	if (result.issues) {
+		throw new Error(JSON.stringify(result.issues, null, 2));
+	}
+
+	return result.value;
+}

--- a/packages/spellbook/package.json
+++ b/packages/spellbook/package.json
@@ -54,7 +54,7 @@
 		"test": "bun test"
 	},
 	"dependencies": {
-		"@standard-schema/spec": "^1.0.0",
+		"@standard-schema/spec": "catalog:",
 		"@usirin/forge": "workspace:",
 		"ws": "catalog:",
 		"zod": "catalog:"

--- a/packages/spellbook/src/index.test.ts
+++ b/packages/spellbook/src/index.test.ts
@@ -3,7 +3,7 @@ import {z} from "zod";
 import {createSpellCaster} from "./caster";
 import {createSpellbookServer} from "./server";
 import {createSpell, createSpellbook} from "./spellbook";
-import * as Transport from "./transport";
+
 import {
 	createClientTransport,
 	createEmitterPair,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@rslib/core':
       specifier: 0.4.1
       version: 0.4.1
+    '@standard-schema/spec':
+      specifier: 1.0.0
+      version: 1.0.0
     '@types/ws':
       specifier: 8.5.14
       version: 8.5.14
@@ -71,6 +74,9 @@ importers:
 
   packages/forge:
     dependencies:
+      '@standard-schema/spec':
+        specifier: 'catalog:'
+        version: 1.0.0
       base-x:
         specifier: ^4.0.0
         version: 4.0.0
@@ -81,6 +87,9 @@ importers:
       '@types/bun':
         specifier: latest
         version: 1.2.3
+      zod:
+        specifier: 'catalog:'
+        version: 3.24.2
 
   packages/layout-tree:
     dependencies:
@@ -167,7 +176,7 @@ importers:
   packages/spellbook:
     dependencies:
       '@standard-schema/spec':
-        specifier: ^1.0.0
+        specifier: 'catalog:'
         version: 1.0.0
       '@usirin/forge':
         specifier: 'workspace:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ catalog:
   "@radix-ui/react-icons": 1.3.2
   "@radix-ui/themes": 3.2.0
   "@rslib/core": 0.4.1
+  "@standard-schema/spec": 1.0.0
   "@xstate/react": 5.0.2
   "@types/react": 19.0.8
   "@types/react-dom": 19.0.3


### PR DESCRIPTION
- Integrate @standard-schema/spec for type-safe entity creation
- Implement `struct` function for creating validated entities
- Add synchronous and asynchronous validation utilities
- Update package dependencies to include zod and @standard-schema/spec
- Enhance forge package with improved schema validation capabilities
