### PR TITLE
[spellbook] version 0.2.0

### DIFF
--- a/packages/spellbook/package.json
+++ b/packages/spellbook/package.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json.schemastore.org/package",
 	"name": "@usirin/spellbook",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"description": "Type-safe API surfaces that work across process boundaries",
 	"type": "module",
 	"private": false,
@@ -35,7 +35,7 @@
 	},
 	"dependencies": {
 		"@standard-schema/spec": "catalog:",
-		"@usirin/forge": "workspace:"
+		"@usirin/forge": "workspace:*"
 	},
 	"devDependencies": {
 		"@rslib/core": "catalog:",


### PR DESCRIPTION
Bump package version to 0.2.0 in package.json to reflect new changes and update the @usirin/forge dependency specification to use "workspace:*".
