### PR TITLE
[layout-tree] version 0.2.0

### DIFF
--- a/packages/layout-tree/package.json
+++ b/packages/layout-tree/package.json
@@ -1,17 +1,28 @@
 {
+	"$schema": "https://json.schemastore.org/package",
 	"name": "@usirin/layout-tree",
-	"version": "0.1.0",
-	"private": false,
+	"version": "0.2.0",
+	"description": "Layout tree management for UI components",
 	"type": "module",
+	"private": false,
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/src/index.d.ts",
 	"exports": {
 		".": {
 			"types": "./dist/src/index.d.ts",
+			"require": "./dist/index.cjs",
 			"import": "./dist/index.js"
 		}
 	},
-	"module": "./dist/index.js",
-	"types": "./dist/src/index.d.ts",
-	"files": ["dist"],
+	"files": ["dist", "README.md"],
+	"homepage": "https://github.com/usirin/monorepo/packages/layout-tree",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/usirin/monorepo"
+	},
+	"keywords": ["layout", "tree", "ui", "components", "typescript"],
 	"scripts": {
 		"build": "rslib build",
 		"dev": "rslib build --watch",
@@ -19,13 +30,11 @@
 	},
 	"dependencies": {
 		"@usirin/forge": "workspace:*",
-		"immer": "catalog:",
-		"lodash.get": "^4.4.2"
+		"immer": "catalog:"
 	},
 	"devDependencies": {
 		"@rslib/core": "catalog:",
-		"@types/bun": "latest",
-		"@types/lodash.get": "^4.4.9"
+		"@types/bun": "latest"
 	},
 	"peerDependencies": {
 		"typescript": "catalog:"

--- a/packages/layout-tree/rslib.config.ts
+++ b/packages/layout-tree/rslib.config.ts
@@ -8,6 +8,12 @@ export default defineConfig({
 			dts: true,
 			bundle: false,
 		},
+		{
+			format: "cjs",
+			syntax: "es2021",
+			dts: true,
+			bundle: false,
+		},
 	],
 	source: {
 		exclude: ["**/*.test.ts"],

--- a/packages/layout-tree/src/index.ts
+++ b/packages/layout-tree/src/index.ts
@@ -5,7 +5,6 @@
 
 import {type Entity, factory} from "@usirin/forge";
 import {produce} from "immer";
-import get from "lodash.get";
 
 /** Represents the orientation of a stack of windows */
 export type Orientation = "horizontal" | "vertical";
@@ -95,12 +94,17 @@ export const createTree = factory("tree", (root?: Stack) => ({
  */
 export function getAt(stack: Stack, stackPath: StackPath): Stack | Window | null {
 	if (stackPath.length === 0) return stack;
-	const thing = get(
-		stack,
-		stackPath.flatMap((n) => ["children", n]),
-	);
 
-	return (thing as Stack | Window) ?? null;
+	let current: any = stack;
+	for (let i = 0; i < stackPath.length; i++) {
+		const index = stackPath[i];
+		if (!current.children || !current.children[index]) {
+			return null;
+		}
+		current = current.children[index];
+	}
+
+	return current as Stack | Window;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,9 +102,6 @@ importers:
       immer:
         specifier: 'catalog:'
         version: 10.1.1
-      lodash.get:
-        specifier: ^4.4.2
-        version: 4.4.2
       typescript:
         specifier: 'catalog:'
         version: 5.7.3
@@ -115,9 +112,6 @@ importers:
       '@types/bun':
         specifier: latest
         version: 1.2.4
-      '@types/lodash.get':
-        specifier: ^4.4.9
-        version: 4.4.9
 
   packages/otp:
     dependencies:
@@ -1934,9 +1928,6 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/lodash.get@4.4.9':
-    resolution: {integrity: sha512-J5dvW98sxmGnamqf+/aLP87PYXyrha9xIgc2ZlHl6OHMFR2Ejdxep50QfU0abO1+CH6+ugx+8wEUN1toImAinA==}
-
   '@types/lodash.omit@4.5.9':
     resolution: {integrity: sha512-zuAVFLUPJMOzsw6yawshsYGgq2hWUHtsZgeXHZmSFhaQQFC6EQ021uDKHkSjOpNhSvtNSU9165/o3o/Q51GpTw==}
 
@@ -2590,10 +2581,6 @@ packages:
 
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
-
-  lodash.get@4.4.2:
-    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
-    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.omit@4.5.0:
     resolution: {integrity: sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==}
@@ -4831,10 +4818,6 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/lodash.get@4.4.9':
-    dependencies:
-      '@types/lodash': 4.17.15
-
   '@types/lodash.omit@4.5.9':
     dependencies:
       '@types/lodash': 4.17.15
@@ -5545,8 +5528,6 @@ snapshots:
   loader-runner@4.3.0: {}
 
   locate-character@3.0.0: {}
-
-  lodash.get@4.4.2: {}
 
   lodash.omit@4.5.0: {}
 


### PR DESCRIPTION
Remove deprecated lodash.get package and its types from package.json and pnpm-lock.yaml, update version to 0.2.0, and enhance package metadata.
